### PR TITLE
[default, step9] 예외 로깅 및 응답 처리 핸들러 구현 및 filter를 통한 대기열 검증 구현

### DIFF
--- a/src/main/java/hhplus/concertreservation/app/application/service/PaymentService.java
+++ b/src/main/java/hhplus/concertreservation/app/application/service/PaymentService.java
@@ -10,10 +10,12 @@ import hhplus.concertreservation.config.exception.ErrorCode;
 import hhplus.concertreservation.config.exception.FailException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class PaymentService {
@@ -29,6 +31,7 @@ public class PaymentService {
     public Payment useUserPoint(Long userId, Long reservationId, Long amount) {
 
         Reservation reservation = Reservation.getOrThrowIfNotFound(reservationRepository.findById(reservationId));
+        log.info("좌석 예약 요청 유저의 ID : {}", reservation.getUserId());
 
         try {
             // 대기열 만료 확인 (만료된 토큰은 이미 스케줄러에 의해 삭제됨)
@@ -55,6 +58,7 @@ public class PaymentService {
             return payment;
 
         } catch (FailException e) {
+            log.warn("결제가 실패했습니다. reservation ID : {}", reservation.getId());
             // 예약 상태 실패로 변환
             reservation.changeStatus(ReservationStatus.FAILED);
             // 좌석 예약 가능 상태로 변환

--- a/src/main/java/hhplus/concertreservation/app/application/service/PaymentService.java
+++ b/src/main/java/hhplus/concertreservation/app/application/service/PaymentService.java
@@ -6,12 +6,11 @@ import hhplus.concertreservation.app.domain.constant.SeatStatus;
 import hhplus.concertreservation.app.domain.constant.TransactionType;
 import hhplus.concertreservation.app.domain.entity.*;
 import hhplus.concertreservation.app.domain.repository.*;
-import hhplus.concertreservation.config.exception.ErrorCode;
 import hhplus.concertreservation.config.exception.FailException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -28,28 +27,21 @@ public class PaymentService {
     private final UsersRepository usersRepository;
 
     @Transactional
-    public Payment useUserPoint(Long userId, Long reservationId, Long amount) {
+    public Payment payment(Long userId, Long reservationId, Long amount) {
 
         Reservation reservation = Reservation.getOrThrowIfNotFound(reservationRepository.findById(reservationId));
+        Users user = Users.getOrThrowIfNotFound(usersRepository.findById(userId));
         log.info("좌석 예약 요청 유저의 ID : {}", reservation.getUserId());
 
         try {
             // 대기열 만료 확인 (만료된 토큰은 이미 스케줄러에 의해 삭제됨)
             Queue queue = Queue.getOrThrowIfNotFound(queueRepository.findByUserId(userId));
-            System.out.println("--------------------대기열 토큰 확인");
-            Users user = Users.getOrThrowIfNotFound(usersRepository.findById(userId));
-            System.out.println("--------------------유저 확인");
-
             // 유저 포인트 사용 (유저의 남은 잔액부터 확인)
             user.usePoints(amount);
             // 결제 내역 생성
             Payment payment = paymentRepository.save(Payment.create(user.getId(), reservationId, amount, PaymentStatus.SUCCESS));
-            System.out.println("--------------------결제 내역 생성");
-
             // 원장 생성
             ledgerRepository.save(Ledger.create(userId, amount, TransactionType.USE));
-            System.out.println("--------------------원장 생성");
-
             // 예약 상태 성공으로 변환
             reservation.changeStatus(ReservationStatus.SUCCESS);
             // 만료 시키기 위해 만료 시간 변경
@@ -63,9 +55,9 @@ public class PaymentService {
             reservation.changeStatus(ReservationStatus.FAILED);
             // 좌석 예약 가능 상태로 변환
             Seat seat = Seat.getOrThrowIfNotFound(seatRepository.findById(reservation.getSeatId()));
-            System.out.println("--------------------좌석 조회 확인");
             seat.changeStatus(SeatStatus.AVAILABLE);
-            throw new FailException(ErrorCode.PAYMENT_FAILED);
+            // 결제 내역 생성
+            return paymentRepository.save(Payment.create(user.getId(), reservationId, amount, PaymentStatus.FAILED));
         }
     }
 }

--- a/src/main/java/hhplus/concertreservation/app/application/service/QueueService.java
+++ b/src/main/java/hhplus/concertreservation/app/application/service/QueueService.java
@@ -6,6 +6,7 @@ import hhplus.concertreservation.app.domain.entity.Queue;
 import hhplus.concertreservation.app.domain.repository.QueueRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class QueueService {
@@ -21,12 +23,14 @@ public class QueueService {
 
     @Transactional
     public Queue getQueue(Long userId) {
+        log.info("토큰 발급 요청 유저의 ID : {}", userId);
         return queueRepository.findByUserId(userId)
                 .orElseGet(() -> queueRepository.save(Queue.create(userId)));
     } 
 
     public QueryQueueDto queryQueue(String token) {
         Queue searchedQueue = Queue.getOrThrowIfNotFound(queueRepository.findByToken(token));
+        log.info("토큰 조회 요청 유저의 ID : {}", searchedQueue.getUserId());
         Long queueCount = queueRepository.countByUserQueueStatusAndUserIdLessThan(QueueStatus.READY, searchedQueue.getId());
         return QueryQueueDto.of(searchedQueue, queueCount);
     }

--- a/src/main/java/hhplus/concertreservation/app/application/service/ReservationService.java
+++ b/src/main/java/hhplus/concertreservation/app/application/service/ReservationService.java
@@ -9,10 +9,12 @@ import hhplus.concertreservation.app.domain.repository.ReservationRepository;
 import hhplus.concertreservation.app.domain.repository.SeatRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ReservationService {
@@ -30,6 +32,7 @@ public class ReservationService {
         // 대기열 5분 설정
         Queue queue = Queue.getOrThrowIfNotFound(queueRepository.findByToken(token));
         queue.changeExpiredAt(LocalDateTime.now().plusMinutes(5));
+        log.info("좌석 예약 요청 유저의 ID : {}", queue.getUserId());
         // 좌석 예약 상태로 변환
         seat.changeStatus(SeatStatus.RESERVED);
         // 예약 생성

--- a/src/main/java/hhplus/concertreservation/app/application/service/ReservationService.java
+++ b/src/main/java/hhplus/concertreservation/app/application/service/ReservationService.java
@@ -24,13 +24,13 @@ public class ReservationService {
     private final QueueRepository queueRepository;
 
     @Transactional
-    public Reservation reserveSeat(String token, Long concertId, Long seatNumber) {
+    public Reservation reserveSeat(Long userId, Long concertId, Long seatNumber) {
         // 비관적 락
         Seat seat = Seat.getOrThrowIfNotFound(seatRepository.findByConcertIdAndSeatNumber(concertId, seatNumber));
         // AVAILABLE이 아니라면 예외
         Seat.validateIfAvailable(seat);
         // 대기열 5분 설정
-        Queue queue = Queue.getOrThrowIfNotFound(queueRepository.findByToken(token));
+        Queue queue = Queue.getOrThrowIfNotFound(queueRepository.findByUserId(userId));
         queue.changeExpiredAt(LocalDateTime.now().plusMinutes(5));
         log.info("좌석 예약 요청 유저의 ID : {}", queue.getUserId());
         // 좌석 예약 상태로 변환

--- a/src/main/java/hhplus/concertreservation/app/application/service/SeatService.java
+++ b/src/main/java/hhplus/concertreservation/app/application/service/SeatService.java
@@ -17,8 +17,4 @@ public class SeatService {
     public List<Seat> getSeats(Long concertId) {
         return seatRepository.findByConcertIdAndSeatStatus(concertId, SeatStatus.AVAILABLE);
     }
-
-    public Seat getSeat(Long concertId, Long seatNumber) {
-        return Seat.getOrThrowIfNotFound(seatRepository.findByConcertIdAndSeatNumber(concertId, seatNumber));
-    }
 }

--- a/src/main/java/hhplus/concertreservation/app/application/service/UsersService.java
+++ b/src/main/java/hhplus/concertreservation/app/application/service/UsersService.java
@@ -7,8 +7,10 @@ import hhplus.concertreservation.app.domain.repository.LedgerRepository;
 import hhplus.concertreservation.app.domain.repository.UsersRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class UsersService {
@@ -18,14 +20,14 @@ public class UsersService {
 
     @Transactional
     public void chargeUserPoint(Long userId, Long amount) {
-        // 유저의 포인트 충전
+        log.info("포인트 충전 요청 유저의 ID : {}", userId);
         Users user = Users.getOrThrowIfNotFound(usersRepository.findById(userId));
         user.chargePoints(amount);
-        // 원장 생성
         ledgerRepository.save(Ledger.create(userId, amount, TransactionType.CHARGE));
     }
 
     public Users getUserPoint(Long userId) {
+        log.info("포인트 조회 요청 유저의 ID : {}", userId);
         return Users.getOrThrowIfNotFound(usersRepository.findById(userId));
     }
 }

--- a/src/main/java/hhplus/concertreservation/app/domain/entity/Queue.java
+++ b/src/main/java/hhplus/concertreservation/app/domain/entity/Queue.java
@@ -54,4 +54,9 @@ public class Queue {
         return optionalQueue.orElseThrow(
                 () -> new FailException(ErrorCode.EXPIRED_QUEUE_TOKEN));
     }
+
+    public void checkActiveOrThrow() {
+        if (this.getUserQueueStatus() != QueueStatus.ACTIVE)
+            throw new FailException(ErrorCode.INVALID_QUEUE_STATUS);
+    }
 }

--- a/src/main/java/hhplus/concertreservation/app/domain/entity/Reservation.java
+++ b/src/main/java/hhplus/concertreservation/app/domain/entity/Reservation.java
@@ -42,6 +42,6 @@ public class Reservation {
 
     public static Reservation getOrThrowIfNotFound(Optional<Reservation> optionalReservation) {
         return optionalReservation.orElseThrow(
-                () -> new FailException(ErrorCode.RESERVATION_NOT_FOUND));
+                () -> new FailException(ErrorCode.RESERVATION_NOT_FOUND, FailException.LogLevel.ERROR));
     }
 }

--- a/src/main/java/hhplus/concertreservation/app/domain/entity/Seat.java
+++ b/src/main/java/hhplus/concertreservation/app/domain/entity/Seat.java
@@ -32,12 +32,12 @@ public class Seat {
 
     public static Seat getOrThrowIfNotFound(Optional<Seat> optionalSeat) {
         return optionalSeat.orElseThrow(
-                () -> new FailException(ErrorCode.SEAT_NOT_FOUND));
+                () -> new FailException(ErrorCode.SEAT_NOT_FOUND, FailException.LogLevel.ERROR));
     }
 
     public static void validateIfAvailable(Seat seat) {
         if (seat.getSeatStatus() != SeatStatus.AVAILABLE) {
-            throw new FailException(ErrorCode.RESERVED_SEAT);
+            throw new FailException(ErrorCode.RESERVED_SEAT, FailException.LogLevel.WARN);
         }
     }
 }

--- a/src/main/java/hhplus/concertreservation/app/domain/entity/Users.java
+++ b/src/main/java/hhplus/concertreservation/app/domain/entity/Users.java
@@ -35,6 +35,6 @@ public class Users {
 
     public static Users getOrThrowIfNotFound(Optional<Users> optionalUsers) {
         return optionalUsers.orElseThrow(
-                () -> new FailException(ErrorCode.USER_NOT_FOUND));
+                () -> new FailException(ErrorCode.USER_NOT_FOUND, FailException.LogLevel.ERROR));
     }
 }

--- a/src/main/java/hhplus/concertreservation/app/interfaces/controller/ConcertController.java
+++ b/src/main/java/hhplus/concertreservation/app/interfaces/controller/ConcertController.java
@@ -17,8 +17,7 @@ public class ConcertController {
 
     @GetMapping("/concert")
     public ResponseEntity<List<ConcertDateTimeResponse>> concertDateTime(
-            @RequestHeader String token,
-            @RequestParam String concertName
+            @RequestParam("concertName") String concertName
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(concertService.getConcerts(concertName)

--- a/src/main/java/hhplus/concertreservation/app/interfaces/controller/PaymentController.java
+++ b/src/main/java/hhplus/concertreservation/app/interfaces/controller/PaymentController.java
@@ -2,6 +2,7 @@ package hhplus.concertreservation.app.interfaces.controller;
 
 import hhplus.concertreservation.app.application.service.PaymentService;
 import hhplus.concertreservation.app.interfaces.request.UsePointRequest;
+import hhplus.concertreservation.app.interfaces.response.PaymentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,12 +17,10 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping("/payment")
-    public ResponseEntity<String> payment(
+    public ResponseEntity<PaymentResponse> payment(
             @RequestBody UsePointRequest request
     ) {
-        paymentService.useUserPoint(request.userId(), request.reservationId(), request.amount());
-
         return ResponseEntity.status(HttpStatus.OK)
-                .body("성공적으로 결제되었습니다.");
+                .body(PaymentResponse.from(paymentService.payment(request.userId(), request.reservationId(), request.amount())));
     }
 }

--- a/src/main/java/hhplus/concertreservation/app/interfaces/controller/QueueController.java
+++ b/src/main/java/hhplus/concertreservation/app/interfaces/controller/QueueController.java
@@ -16,7 +16,7 @@ public class QueueController {
 
     @PostMapping("/queue/issue")
     public ResponseEntity<IssueQueueResponse> issueQueueToken(
-            @RequestParam Long userId
+            @RequestParam("userId") Long userId
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(IssueQueueResponse.from(queueService.getQueue(userId)));
@@ -24,7 +24,7 @@ public class QueueController {
 
     @GetMapping("/queue/query")
     public ResponseEntity<QueryQueueResponse> queryQueueToken(
-            @RequestHeader String token
+            @RequestHeader("AuthorizationQueue") String token
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(QueryQueueResponse.from(queueService.queryQueue(token)));

--- a/src/main/java/hhplus/concertreservation/app/interfaces/controller/ReservationController.java
+++ b/src/main/java/hhplus/concertreservation/app/interfaces/controller/ReservationController.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -19,11 +18,10 @@ public class ReservationController {
 
     @GetMapping("/reservation")
     public ResponseEntity<ReservationResponse> reservation(
-            @RequestHeader String token,
             @RequestBody ReservationRequest request
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ReservationResponse.from(
-                        reservationService.reserveSeat(token, request.concertId(), request.seatNumber())));
+                        reservationService.reserveSeat(request.userId(), request.concertId(), request.seatNumber())));
     }
 }

--- a/src/main/java/hhplus/concertreservation/app/interfaces/controller/SeatController.java
+++ b/src/main/java/hhplus/concertreservation/app/interfaces/controller/SeatController.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -20,7 +19,6 @@ public class SeatController {
 
     @GetMapping("/seat/{concert-id}")
     public ResponseEntity<List<ConcertSeatResponse>> concertSeat(
-            @RequestHeader String token,
             @PathVariable("concert-id") Long concertId
     ) {
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/hhplus/concertreservation/app/interfaces/request/ReservationRequest.java
+++ b/src/main/java/hhplus/concertreservation/app/interfaces/request/ReservationRequest.java
@@ -1,6 +1,7 @@
 package hhplus.concertreservation.app.interfaces.request;
 
 public record ReservationRequest(
+        Long userId,
         Long concertId,
         Long seatNumber
 ) {

--- a/src/main/java/hhplus/concertreservation/app/interfaces/response/PaymentResponse.java
+++ b/src/main/java/hhplus/concertreservation/app/interfaces/response/PaymentResponse.java
@@ -1,0 +1,16 @@
+package hhplus.concertreservation.app.interfaces.response;
+
+import hhplus.concertreservation.app.domain.constant.PaymentStatus;
+import hhplus.concertreservation.app.domain.entity.Payment;
+
+public record PaymentResponse(
+        Long reservationId,
+        PaymentStatus paymentStatus
+) {
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(
+                payment.getReservationId(),
+                payment.getPaymentStatus()
+        );
+    }
+}

--- a/src/main/java/hhplus/concertreservation/config/QueueAuthenticationFilter.java
+++ b/src/main/java/hhplus/concertreservation/config/QueueAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package hhplus.concertreservation.config;
+
+import hhplus.concertreservation.app.domain.entity.Queue;
+import hhplus.concertreservation.app.domain.repository.QueueRepository;
+import hhplus.concertreservation.config.exception.FailException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class QueueAuthenticationFilter extends OncePerRequestFilter {
+
+    private final QueueRepository queueRepository;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private String filterProcessesUrl = "/seat/**";
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return !pathMatcher.match(filterProcessesUrl, path);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = request.getHeader("AuthorizationQueue");
+        log.info("대기열 인증 토큰의 헤더값: {}", token);
+
+        try {
+            Queue queue = Queue.getOrThrowIfNotFound(queueRepository.findByToken(token));
+            queue.checkActiveOrThrow();
+
+            filterChain.doFilter(request, response);
+        } catch (FailException e) {
+            log.info("대기열 인증 토큰이 없거나 대기열 순번이 아닙니다: {}", token);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("토큰 인증에 실패했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/hhplus/concertreservation/config/SecurityConfig.java
+++ b/src/main/java/hhplus/concertreservation/config/SecurityConfig.java
@@ -1,0 +1,42 @@
+package hhplus.concertreservation.config;
+
+import hhplus.concertreservation.app.domain.repository.QueueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final QueueRepository queueRepository;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(
+                        queueAuthenticationFilter(),
+                        UsernamePasswordAuthenticationFilter.class
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public QueueAuthenticationFilter queueAuthenticationFilter() {
+        return new QueueAuthenticationFilter(queueRepository);
+    }
+}

--- a/src/main/java/hhplus/concertreservation/config/exception/ErrorCode.java
+++ b/src/main/java/hhplus/concertreservation/config/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package hhplus.concertreservation.config.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    EXPIRED_QUEUE_TOKEN("E100", "만료된 토큰. 대기열 토큰을 반급받아 주세요."),
+    USER_NOT_FOUND("E101", "존재하지 않는 유저입니다."),
+    SEAT_NOT_FOUND("E102", "존재하지 않는 좌석입니다."),
+    RESERVED_SEAT("E103", "이미 예약된 좌석입니다."),
+    USER_POINT_NOT_ENOUGH("E104", "사용하려는 포인트가 부족합니다."),
+    RESERVATION_NOT_FOUND("E105", "존재하지 않는 예약입니다."),
+    PAYMENT_FAILED("E106", "결제가 실패했습니다."),
+    INVALID_QUEUE_STATUS("E107", "API 요청이 가능한 대기열 상태가이 아닙니다"),
+    ;
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/hhplus/concertreservation/config/exception/ErrorRes.java
+++ b/src/main/java/hhplus/concertreservation/config/exception/ErrorRes.java
@@ -1,0 +1,7 @@
+package hhplus.concertreservation.config.exception;
+
+public record ErrorRes(
+        String errorName,
+        String errorMessage
+) {
+}

--- a/src/main/java/hhplus/concertreservation/config/exception/FailException.java
+++ b/src/main/java/hhplus/concertreservation/config/exception/FailException.java
@@ -1,0 +1,31 @@
+package hhplus.concertreservation.config.exception;
+
+import lombok.Getter;
+
+@Getter
+public class FailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final LogLevel logLevel;
+
+    public FailException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.logLevel = LogLevel.INFO;
+    }
+
+    public FailException(ErrorCode errorCode, LogLevel logLevel) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.logLevel = logLevel;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ErrorCode: %s, Message: %s", errorCode.getCode(), errorCode.getMessage());
+    }
+
+    public enum LogLevel {
+        DEBUG, INFO, WARN, ERROR
+    }
+}

--- a/src/main/java/hhplus/concertreservation/config/exception/RestApiControllerAdvice.java
+++ b/src/main/java/hhplus/concertreservation/config/exception/RestApiControllerAdvice.java
@@ -1,0 +1,31 @@
+package hhplus.concertreservation.config.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice
+class RestApiControllerAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(FailException.class)
+    public ResponseEntity<ErrorRes> handleFailException(FailException e) {
+        switch (e.getLogLevel()) {
+            case ERROR -> log.error("치명적인 에러입니다. 빠르게 확인 바랍니다. : {} - ErrorCode: {}", e.getMessage(), e.getErrorCode().name(), e);
+            case WARN -> log.warn("잠재적 에러입니다. 주의 깊게 확인 바랍니다. : {} - ErrorCode: {}", e.getMessage(), e.getErrorCode().name(), e);
+            default -> log.info("클라이언트 에러입니다. : {} - ErrorCode: {}", e.getMessage(), e.getErrorCode().name(), e);
+        }
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new ErrorRes(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorRes> handleException(Exception e) {
+        log.error("UnhandledException : {}", e.getMessage(), e);
+        return ResponseEntity.status(500)
+                .body(new ErrorRes("500", "서버 에러가 발생했습니다."));
+    }
+}

--- a/src/test/java/hhplus/concertreservation/application/service/ReservationServiceTest.java
+++ b/src/test/java/hhplus/concertreservation/application/service/ReservationServiceTest.java
@@ -43,7 +43,6 @@ class ReservationServiceTest {
 
     @Test
     void 좌석예약_성공() {
-        String token = "some-token";
         Long concertId = 1L;
         Long seatNumber = 1L;
         Long userId = 1L;
@@ -57,10 +56,10 @@ class ReservationServiceTest {
                 .build();
 
         when(seatRepository.findByConcertIdAndSeatNumber(concertId, seatNumber)).thenReturn(Optional.of(seat));
-        when(queueRepository.findByToken(token)).thenReturn(Optional.of(queue));
+        when(queueRepository.findByUserId(userId)).thenReturn(Optional.of(queue));
         when(reservationRepository.save(any(Reservation.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        Reservation result = sut.reserveSeat(token, concertId, seatNumber);
+        Reservation result = sut.reserveSeat(userId, concertId, seatNumber);
 
         assertNotNull(result);
         assertEquals(ReservationStatus.PENDING, result.getReservationStatus());
@@ -70,9 +69,9 @@ class ReservationServiceTest {
 
     @Test
     void 좌석이예매된상태라면_예외발생() {
-        String token = "some-token";
         Long concertId = 1L;
         Long seatNumber = 1L;
+        Long userId = 1L;
 
         Seat seat = new Seat();
         seat.changeStatus(SeatStatus.RESERVED);
@@ -80,23 +79,23 @@ class ReservationServiceTest {
         when(seatRepository.findByConcertIdAndSeatNumber(concertId, seatNumber)).thenReturn(Optional.of(seat));
 
         assertThrows(RuntimeException.class, () -> {
-            sut.reserveSeat(token, concertId, seatNumber);
+            sut.reserveSeat(userId, concertId, seatNumber);
         });
     }
 
     @Test
     void 대기열이만료되었다면_좌석예약실패() {
-        String token = "invalid-token";
         Long concertId = 1L;
         Long seatNumber = 1L;
+        Long userId = 1L;
 
         Seat seat = new Seat();
 
         when(seatRepository.findByConcertIdAndSeatNumber(concertId, seatNumber)).thenReturn(Optional.of(seat));
-        when(queueRepository.findByToken(token)).thenThrow(new RuntimeException("대기열을 찾을 수 없습니다"));
+        when(queueRepository.findByUserId(userId)).thenThrow(new RuntimeException("대기열을 찾을 수 없습니다"));
 
         assertThrows(RuntimeException.class, () -> {
-            sut.reserveSeat(token, concertId, seatNumber);
+            sut.reserveSeat(userId, concertId, seatNumber);
         });
     }
 

--- a/src/test/java/hhplus/concertreservation/application/service/SeatServiceTest.java
+++ b/src/test/java/hhplus/concertreservation/application/service/SeatServiceTest.java
@@ -12,9 +12,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,34 +46,5 @@ class SeatServiceTest {
 
         assertEquals(2, result.size());
         verify(seatRepository).findByConcertIdAndSeatStatus(concertId, SeatStatus.AVAILABLE);
-    }
-
-    @Test
-    void 좌석조회_예외발생() {
-        Long concertId = 1L;
-        Long seatNumber = 10L;
-
-        when(seatRepository.findByConcertIdAndSeatNumber(concertId, seatNumber))
-                .thenReturn(Optional.empty());
-
-        assertThrows(RuntimeException.class, () -> {
-            sut.getSeat(concertId, seatNumber);
-        });
-    }
-
-    @Test
-    void 좌석조회_성공() {
-        Long concertId = 1L;
-        Long seatNumber = 1L;
-        Seat seat = new Seat();
-        seat.changeStatus(SeatStatus.AVAILABLE);
-
-        when(seatRepository.findByConcertIdAndSeatNumber(concertId, seatNumber))
-                .thenReturn(Optional.of(seat));
-
-        Seat result = sut.getSeat(concertId, seatNumber);
-
-        assertNotNull(result);
-        assertEquals(seat.getSeatStatus(), result.getSeatStatus());
     }
 }


### PR DESCRIPTION
작업 내역
1. 글로벌 에러 핸들러를 통한 예외 로깅 및 응답 처리
- RestApiControllerAdvice 라는 핸들러를 만들었습니다.
- 핸들러에선 커스텀 예외(FailException)를 처리하며 FailException의 logLevel에 따라 로깅을 분기해보았습니다.
- ErrorCode라는 enum에서 비즈니스 별 발생할 수 있는 에러 코드를 모두 정의했습니다.
- 핸들러는 FailException을 처리하고 응답값(ResponseEntity)으로 ErrorRes를 반환하도록 관리 체계를 구축했습니다.

2. filter를 통한 대기열 검증 구현
- 제가 구현한 시스템 성격에 적합하게 filter를 선택하였고 이유는 다음과 같습니다.
- 좌석 조회, 예약, 결제 과정에서 토큰에 대한 검증은 꾸준히 발생합니다.
- 하지만 상황에 따라 처리해야 하는 로직이 다릅니다. 즉, 어떤 부분은 비즈니스 로직에 해당합니다.
- '콘서트  서비스' 기획 단계에서 저는 대기열 토큰의 사용 범위를 좌석 조회로 한정지었습니다. 왜냐하면 MSA 환경으로 생각했을 때 사용자의 트래픽을 Queue(대기열) 서버와 Seat(좌석) 서버로 나누고 싶었기 때문입니다.  [플로우 차트에서 확인할 수 있습니다](https://github.com/kimgun95/hhplus-concert-reservation?tab=readme-ov-file#%ED%94%8C%EB%A1%9C%EC%9A%B0-%EC%B0%A8%ED%8A%B8)
- 따라서 좌석 조회 요청시 대기열 토큰을 검증하는 로직을 filter를 통해 구현하게 되었습니다.

3. 모든 API가 정상적으로 기능을 제공하도록 완성
- postman을 통해 모든 API가 정상적으로 응답값을 반환하는 것을 확인했습니다.
- 특히 마지막 payment(결제) 과정에서 결제 실패시 진행되어야 하는 로직이 진행되지 않는 에러가 있었지만 리팩토링 하였습니다.

리뷰 포인트
- 멘토링 시간 때 알려주신 상위 패키지 app, config로 패키지를 분리해보았습니다. 그리고 config가 공통 모듈을 저장하는 곳이라 생각하고 exception 디렉토리를 넣었습니다. 해당 디렉토리가 존재하면 더 좋을 위치가 있을까요?
- dm으로 얻은 조언과 제 시스템 설계를 바탕으로 filter를 활용해보았습니다. 추가적으로 interceptor를 활용하면 좋았을 포인트가 따로 있을까요? (콘서트 예약 시스템 관점에서)
- 결제 실패시 진행해야 하는 비즈니스 로직 때문에 에러를 throw하지 못했습니다. 저는 무언가 실패를 했을 때 에러를 throw하는게 맞다고 생각하는데 이 생각이 옳은 걸까요? 아니면 실패를 그냥 로깅하고 controller에서 정상적인 응답을 반환하는 것이 맞는 걸까요?